### PR TITLE
Changes to check for DB instance for review

### DIFF
--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -37,7 +37,9 @@ if (!window.Cordova) window.Cordova = window.cordova;
     this.dbname = dbargs.name + ".db";
     dbargs.name = this.dbname;
 
-    this.dbfeatures = { isSQLitePlugin: true };
+    this.dbprop = {
+      isSQLitePlugin: true,
+    };
 
     this.openSuccess = openSuccess;
     this.openError = openError;

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -31,9 +31,13 @@ if (!window.Cordova) window.Cordova = window.cordova;
       throw new Error("Cannot create a SQLitePlugin instance without a db name");
     }
 
+    this.isdatabase = true;
+
     this.dbargs = dbargs;
     this.dbname = dbargs.name + ".db";
     dbargs.name = this.dbname;
+
+    this.dbfeatures = { isSQLitePlugin: true };
 
     this.openSuccess = openSuccess;
     this.openError = openError;
@@ -49,7 +53,7 @@ if (!window.Cordova) window.Cordova = window.cordova;
 
   SQLitePlugin.prototype.openDBs = {};
   SQLitePlugin.prototype.txQueue = [];
-  SQLitePlugin.prototype.features = { isSQLitePlugin: true };
+  //SQLitePlugin.prototype.features = { isSQLitePlugin: true };
 
   SQLitePlugin.prototype.executePragmaStatement = function(sql, success, error) {
     if (!sql) throw new Error("Cannot executeSql without a query");


### PR DESCRIPTION
Submitting changes for review for the following subject: https://groups.google.com/forum/?hl=en#!msg/pgsqlite/CSRAdjkNfbY/Oj6kNGWV654J

This was a request to get the constructor object, which would be awkward given the kind of encapsulation used. As an alternative, provide a member that can be checked very quickly for both existence and a value of truth. To check if an object is really an instance of the plugin db object:

    if (!!db.isdatabase) {
      // transactions on db
    } else {
      // oops not a db
    }