### PR TITLE
Fix iOS error objects not having error constants

### DIFF
--- a/src/ios/SQLitePlugin.m
+++ b/src/ios/SQLitePlugin.m
@@ -531,10 +531,20 @@ static void sqlite_regexp(sqlite3_context* context, int argc, sqlite3_value** va
 #endif
     const char *message = sqlite3_errmsg(db);
 
-    NSMutableDictionary *error = [NSMutableDictionary dictionaryWithCapacity:4];
+    NSMutableDictionary *error = [NSMutableDictionary dictionaryWithCapacity:13];
 
     [error setObject:[NSNumber numberWithInt:webSQLCode] forKey:@"code"];
     [error setObject:[NSString stringWithUTF8String:message] forKey:@"message"];
+
+    // Keep synced with WebSQLError in SQLitePlugin.h
+    [error setObject:[NSNumber numberWithInt:UNKNOWN_ERR] forKey:@"UNKNOWN_ERR"];
+    [error setObject:[NSNumber numberWithInt:DATABASE_ERR] forKey:@"DATABASE_ERR"];
+    [error setObject:[NSNumber numberWithInt:VERSION_ERR] forKey:@"VERSION_ERR"];
+    [error setObject:[NSNumber numberWithInt:TOO_LARGE_ERR] forKey:@"TOO_LARGE_ERR"];
+    [error setObject:[NSNumber numberWithInt:QUOTA_ERR] forKey:@"QUOTA_ERR"];
+    [error setObject:[NSNumber numberWithInt:SYNTAX_ERR] forKey:@"SYNTAX_ERR"];
+    [error setObject:[NSNumber numberWithInt:CONSTRAINT_ERR] forKey:@"CONSTRAINT_ERR"];
+    [error setObject:[NSNumber numberWithInt:TIMEOUT_ERR] forKey:@"TIMEOUT_ERR"];
 
 #if INCLUDE_SQLITE_ERROR_INFO
     [error setObject:[NSNumber numberWithInt:code] forKey:@"sqliteCode"];

--- a/test-www/www/index.html
+++ b/test-www/www/index.html
@@ -891,7 +891,7 @@
               ok(error.hasOwnProperty('message'), "error.message exists");
               // XXX NOT WORKING for Android or WP(8) version of plugin:
               if (isWebSql || (!/Android/.test(navigator.userAgent) && !/MSIE/.test(navigator.userAgent)))
-                strictEqual(error.code, 5, "error.code === SQLException.SYNTAX_ERR (5)");
+                strictEqual(error.code, error.SYNTAX_ERR, "error.code === SQLException.SYNTAX_ERR (5)");
               //equal(error.message, "Request failed: insert into test_table (data) VALUES ,123", "error.message");
               start();
 
@@ -932,7 +932,7 @@
                 ok(!!error['code'], "valid error.code exists");
 
               ok(error.hasOwnProperty('message'), "error.message exists");
-              //strictEqual(error.code, 6, "error.code === SQLException.CONSTRAINT_ERR (6)");
+              //strictEqual(error.code, error.CONSTRAINT_ERR, "error.code === SQLException.CONSTRAINT_ERR (6)");
               //equal(error.message, "Request failed: insert into test_table (data) VALUES (?),123", "error.message");
               start();
 


### PR DESCRIPTION
The error objects returned by the plugin do not have accessible error constants for comparing against `error.code`. Browser implementations (such as Chrome and Safari) provide these, and they allow developers to avoid having to rely upon magic numbers when handling errors from WebSQL.

The following patch brings the error objects from this library into closer API compatibility with other WebSQL implementations and fixes the issues we were seeing about undefined properties.